### PR TITLE
Use color-focused css variable for selected border

### DIFF
--- a/ecosia_keyboard_shortcuts.js
+++ b/ecosia_keyboard_shortcuts.js
@@ -3,7 +3,7 @@ const moveUpKey = "k";
 const searchKey = "?";
 const exitSearchKey = "Escape";
 const extraScroll = 30;
-const borderColor = "blue";
+const borderColor = "var(--color-focused)";
 
 const results = document.querySelectorAll(".web-result, .layout-card, .card-web .result");
 const search = document.querySelector(".search-form__input");


### PR DESCRIPTION
This PR sets the border color to the Ecosia-defined --color-focused variable.

This makes selection clearer when using dark mode.
This feature is requested in a review on the chrome web store