### PR TITLE
Add navigation by number keys

### DIFF
--- a/ecosia_keyboard_shortcuts.js
+++ b/ecosia_keyboard_shortcuts.js
@@ -39,6 +39,12 @@ document.addEventListener("keydown", e => {
 			moveSelectionTo(selected + 1);
 		} else if (e.key == moveUpKey) {
 			moveSelectionTo(selected - 1);
+		} else if (!isNaN(e.key)) {
+			if (e.key == 0) {
+				moveSelectionTo(10);
+			} else {
+				moveSelectionTo(e.key)
+			}
 		} else if (e.key == searchKey) {
 			e.preventDefault();
 			let startSelection = search.value.length;

--- a/ecosia_keyboard_shortcuts.js
+++ b/ecosia_keyboard_shortcuts.js
@@ -43,7 +43,7 @@ document.addEventListener("keydown", e => {
 			if (e.key == 0) {
 				moveSelectionTo(10);
 			} else {
-				moveSelectionTo(e.key)
+				moveSelectionTo(e.key - 1)
 			}
 		} else if (e.key == searchKey) {
 			e.preventDefault();

--- a/ecosia_keyboard_shortcuts.js
+++ b/ecosia_keyboard_shortcuts.js
@@ -11,8 +11,7 @@ let selected = -1;
 
 const isChrome = typeof(browser) === "undefined";
 
-const moveSelection = function(moveBy) {
-	const updated = selected + moveBy;
+const moveSelectionTo = function(updated) {
 	if (updated >= 0 && updated < results.length) {
 		if (selected != -1) {
 			results[selected].style.border = "none";
@@ -37,9 +36,9 @@ const moveSelection = function(moveBy) {
 document.addEventListener("keydown", e => {
 	if (e.target.tagName.toLowerCase() !== "input") {
 		if (e.key == moveDownKey) {
-			moveSelection(1);
+			moveSelectionTo(selected + 1);
 		} else if (e.key == moveUpKey) {
-			moveSelection(-1);
+			moveSelectionTo(selected - 1);
 		} else if (e.key == searchKey) {
 			e.preventDefault();
 			let startSelection = search.value.length;

--- a/ecosia_keyboard_shortcuts.js
+++ b/ecosia_keyboard_shortcuts.js
@@ -41,7 +41,7 @@ document.addEventListener("keydown", e => {
 			moveSelectionTo(selected - 1);
 		} else if (!isNaN(e.key)) {
 			if (e.key == 0) {
-				moveSelectionTo(10);
+				moveSelectionTo(9);
 			} else {
 				moveSelectionTo(e.key - 1)
 			}


### PR DESCRIPTION
People that aren't familiar with VIM bindings might like alternative shortcuts.
This change adds navigation by number keys. The numbers are absolute.

Press `1` to go to the 1st result.
Press `2` to go to the 2nd result.
Press `0` to go to the 10th result.

There are 10 results on one page for me.